### PR TITLE
Remove ship-geckoview step from merge duty

### DIFF
--- a/how-to/releaseduty/merge-duty/merge_duty.rst
+++ b/how-to/releaseduty/merge-duty/merge_duty.rst
@@ -304,12 +304,6 @@ instructions depict.
    `Treeherder <https://treeherder.mozilla.org/#/jobs?repo=mozilla-central>`__.
    It may take a couple of minutes to appear.
 
-Trigger ship-geckoview
-~~~~~~~~~~~~~~~~~~~~~~
-
-Trigger the `ship-geckoview <https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-central%2Fship-geckoview>`__ hook after the decision task completes so android apps can pick up the new gecko major version.
-
-
 Bump ESR version
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
geckoview now ships as part of the regular android nightly, to be picked up by reference-browser.  No need to trigger it manually since the firefox-android merge.

cc @rvandermeulen