### PR TITLE
set baseurl from environment on readthedocs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -66,3 +66,7 @@ html_theme_options = {
         "image_dark": "media/releng-dark.png",
     },
 }
+
+# Set canonical URL from the Read the Docs Domain
+import os
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")


### PR DESCRIPTION
Update conf.py as documented in the "deprecation of Sphinx context injection at build time" announcement:
https://about.readthedocs.com/blog/2024/07/addons-by-default/