### PR TITLE
code review: add some verbiage around backing up assertions as a requester, and verifying them as a reviewer

### DIFF
--- a/explanations/best-practices/code-reviews.rst
+++ b/explanations/best-practices/code-reviews.rst
@@ -32,7 +32,7 @@ Performing a review
 - **Context:** feel free to ask more information from the author. Use "Request Changes" to put the review back in the author's queue.
 - **Posterity:** when a conversation happens on a private or temporary medium, put information back in the review.
 - **Knowledge:** do not feel obligated to review if you don’t have enough experience/context.
-- **Trust, but verify:** verify any non-obvious assertions made in the review request, or implied in changes to the code. Everyone makes mistakes, and an important part of reviewing is catch them before the cause issues!
+- **Trust, but verify:** verify any non-obvious assertions made in the review request, or implied in changes to the code. Everyone makes mistakes, and an important part of reviewing is to catch them before they cause issues!
 - **Pass:** if you know who the best person for review is, remove yourself/the review group and tag the right person directly
 - **Focus:** no need to review what CI already checks (linters, unchanged tests). New/changed tests must be read to ensure they check what the author intends.
 - **Changes needed:** you are empowered to push back when something important is missing (test coverage, lack of context, important cases not covered).

--- a/explanations/best-practices/code-reviews.rst
+++ b/explanations/best-practices/code-reviews.rst
@@ -16,6 +16,7 @@ Requesting a review
 - **Load:** requests should be well balanced among team members so we don't overload a single individual.
 - **Cognitive load:** it's easier for the human brain to focus on several things, one by one, rather than one big thing. Split your changes into several atomic commits. That will speed up the review.
 - **Context:** provide information about why you are proposing this change. It can either be the commit message, the Pull Request title, or the bug report itself.
+- **Evidence:** provide evidence to support any assertions made in your commit message. Eg: "this feature/table/worker is unused" should include pointers to some due diligence that you have done to verify that.
 - **All green:** ensure required checks are passing before submitting review request by creating
 
   - the Pull Request as Draft
@@ -31,6 +32,7 @@ Performing a review
 - **Context:** feel free to ask more information from the author. Use "Request Changes" to put the review back in the author's queue.
 - **Posterity:** when a conversation happens on a private or temporary medium, put information back in the review.
 - **Knowledge:** do not feel obligated to review if you don’t have enough experience/context.
+- **Trust, but verify:** verify any non-obvious assertions made in the review request, or implied in changes to the code. Everyone makes mistakes, and an important part of reviewing is catch them before the cause issues!
 - **Pass:** if you know who the best person for review is, remove yourself/the review group and tag the right person directly
 - **Focus:** no need to review what CI already checks (linters, unchanged tests). New/changed tests must be read to ensure they check what the author intends.
 - **Changes needed:** you are empowered to push back when something important is missing (test coverage, lack of context, important cases not covered).


### PR DESCRIPTION
This is motivated by a whoopsie we had when a worker pool was removed which was asserted to be unused, but actually was, and the issue was not caught in review.