### PR TITLE
Remove out of date sections

### DIFF
--- a/how-to/releaseduty/desktop/esr-to-esr-updates.rst
+++ b/how-to/releaseduty/desktop/esr-to-esr-updates.rst
@@ -83,40 +83,6 @@ have been superceded by the new ``esr*`` rules.
 .. |platform-deprecation| image:: /media/platform-deprecation.png
 .. |watershed| image:: /media/watershed.png
 
-
-The Snap case
--------------
-
-In addition to Balrog, you need to update the Snap store too. For more information about Snap,
-see `ubuntu-snap <ubuntu-snap.html>`__. Steps:
-
-1. ``docker pull snapcore/snapcraft:stable``
-2. ``docker run -ti snapcore/snapcraft:stable``
-3. ``snapcraft login``. If you don't have credentials, use the team account.
-4. ``snapcraft status firefox`` You should see this kind of output::
-
-    Track    Arch    Channel    Version      Revision
-    esr      amd64   stable     78.3.0esr-1  426
-                    candidate  78.2.0esr-1  413
-                    beta       ^            ^
-                    edge       ^            ^
-    latest   amd64   stable     80.0.1-1     418
-                    candidate  81.0-2       425
-                    beta       82.0b1-1     427
-                    edge       ^            ^
-
-
-5. ``snapcraft close firefox esr/candidate`` and you will get::
-
-    Track    Arch    Channel    Version      Revision
-    esr      amd64   stable     78.3.0esr-1  426
-                    candidate  ^            ^
-                    beta       ^            ^
-                    edge       ^            ^
-
-    The esr/candidate channel is now closed.
-
-
 Bouncer and EOL'ing the old ESR branch
 --------------------------------------
 

--- a/how-to/releaseduty/index.rst
+++ b/how-to/releaseduty/index.rst
@@ -282,18 +282,6 @@ If a release is blocked. The normal flow is to:
    work, who is their manager, etc
 7. ask for help if you can’t determine the above.
 
-Good resources within releng:
- * general release configuration (taskgraph): aki
- * scopes / ciadmin: mtabara
- * chainoftrust (cot): aki
- * scriptworker (general): aki
- * beetmoverscript / bouncer / artifact related: mtabara/aki
- * signing / signingscript / autograph: aki
- * balrog / balrogscript / updates related: bhearsum/mtabara
- * l10n / treescript / addonscript: aki/mtabara
- * pushapkscript / mozapkpublisher: mtabara
- * shipit / shipitscript: bhearsum
-
 Other useful resources
 ----------------------
 


### PR DESCRIPTION
The list of people from releng is way out of date and one should just ask in channel instead of pinging a single person. The firefox snap is apparently not managed by us anymore and the link to `ubuntu-snap` was broken ages ago without anyone complaining.