### PR TITLE
Document the preference for re-running github's workflow in ci-admin

### DIFF
--- a/how-to/taskcluster/ci_admin.rst
+++ b/how-to/taskcluster/ci_admin.rst
@@ -19,6 +19,7 @@ Manually
 
 Sometimes you want to run ci-admin manually. Generally this is when we have an urgent bustage fix.
 
+If possible you should avoid running tc-admin locally and re-run the latest `apply (firefoxci)` workflow on the repo's main branch instead.
 
 Setup
 ~~~~~


### PR DESCRIPTION
It's less error prone (dirty working directory, forgetting to pull, running on the wrong instance) and will also notify which might help avoiding some head scratching if someone had done some manual changes