### PR TITLE
Remove the mention to tbdrivers in channels to pay attention to

### DIFF
--- a/how-to/releaseduty/index.rst
+++ b/how-to/releaseduty/index.rst
@@ -64,7 +64,6 @@ You ought to be present and pay attention to conversations happening in:
 * **#sheriffs:mozilla.org** (where CIDuty team helps with various hiccups that infra might encounter))
 * **#releaseduty:mozilla.org** (main RelEng dedicated communication channel for releaseduty)
 * **#firefox-ci:mozilla.org**
-* **#tbdrivers:mozilla.org** (This is the Thunderbird release drivers Matrix channel. **@rjl:mozilla.org** (Rob) should be able to invite you)
 
 Relduty Notifications
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I'm the only one in there and I haven't seen anything we'd need to pay attention to in the past 6+ months. When issues arise, dicsussions should happen in #releaseduty.